### PR TITLE
fix: Load renderer dependencies via script tags instead of require

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <title>DataFlow</title>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
     <link rel="stylesheet" href="styles.css">
+    <!-- Load libraries before the renderer script -->
+    <script src="../node_modules/interactjs/dist/interact.min.js"></script>
+    <script src="../node_modules/leader-line-new/dist/leader-line.min.js"></script>
   </head>
   <body>
     <div class="app-container">

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,5 @@
-// Import necessary libraries
-const interact = require('interactjs');
-const LeaderLine = require('leader-line-new');
+// Libraries are now loaded via <script> tags in index.html,
+// so they are available as global variables (interact, LeaderLine).
 
 // --- Global State ---
 const lines = [];


### PR DESCRIPTION
This commit fixes a bug where UI buttons were unresponsive. The previous fix attempt was incorrect.

The root cause was the use of `require()` in the renderer process (`renderer.js`) while `nodeIntegration` was disabled for security. This caused the script to fail silently before event listeners could be attached.

This commit resolves the issue by:
1.  Adding `<script>` tags to `index.html` to load `interact.js` and `leader-line-new` from `node_modules`.
2.  Removing the corresponding `require()` calls from `renderer.js`.

This approach allows the libraries to be used in the renderer process without compromising the secure default setting of `contextIsolation: true` and `nodeIntegration: false`.